### PR TITLE
Add multi-format image support to WASM module

### DIFF
--- a/lgtmoon-wasm/src/lib.rs
+++ b/lgtmoon-wasm/src/lib.rs
@@ -1,4 +1,7 @@
-use image::{codecs::jpeg::JpegEncoder, ImageBuffer, ImageFormat, Rgb};
+use image::{
+    codecs::{jpeg::JpegEncoder, png::PngEncoder, webp::WebPEncoder},
+    DynamicImage, ImageBuffer, ImageFormat, Rgb,
+};
 use lgtmoon_core::Drawer;
 use wasm_bindgen::{prelude::*, Clamped};
 use web_sys::{js_sys::Uint8Array, Blob};
@@ -10,16 +13,41 @@ pub fn draw_lgtm(bytes: &Uint8Array, mime_type: &str) -> Blob {
     let image =
         image::load_from_memory_with_format(&bytes.to_vec(), format).expect("failed to load image");
     JsValue::from(Clamped::<Box<[u8]>>(
-        draw_lgtm_inner(&image.into_rgb8()).into_boxed_slice(),
+        draw_lgtm_inner(&image.into_rgb8(), format).into_boxed_slice(),
     ))
     .into()
 }
 
-fn draw_lgtm_inner(image: &ImageBuffer<Rgb<u8>, Vec<u8>>) -> Vec<u8> {
+fn draw_lgtm_inner(image: &ImageBuffer<Rgb<u8>, Vec<u8>>, format: ImageFormat) -> Vec<u8> {
     let drawer = Drawer::default();
     let image_buff = drawer.draw_lgtm(image);
     let mut bytes: Vec<_> = Vec::new();
-    let encoder = JpegEncoder::new_with_quality(&mut bytes, 80);
-    image_buff.write_with_encoder(encoder).unwrap();
+
+    match format {
+        ImageFormat::Png => {
+            let encoder = PngEncoder::new(&mut bytes);
+            image_buff.write_with_encoder(encoder).unwrap();
+        }
+        ImageFormat::Jpeg => {
+            let encoder = JpegEncoder::new_with_quality(&mut bytes, 80);
+            image_buff.write_with_encoder(encoder).unwrap();
+        }
+        ImageFormat::Gif => {
+            // GIF uses DynamicImage save method since GifEncoder doesn't implement ImageEncoder
+            let dynamic_img = DynamicImage::ImageRgb8(image_buff);
+            let mut cursor = std::io::Cursor::new(&mut bytes);
+            dynamic_img.write_to(&mut cursor, format).unwrap();
+        }
+        ImageFormat::WebP => {
+            let encoder = WebPEncoder::new_lossless(&mut bytes);
+            image_buff.write_with_encoder(encoder).unwrap();
+        }
+        _ => {
+            // Fallback to JPEG for unsupported formats
+            let encoder = JpegEncoder::new_with_quality(&mut bytes, 80);
+            image_buff.write_with_encoder(encoder).unwrap();
+        }
+    }
+
     bytes
 }


### PR DESCRIPTION
## Summary
- Adds support for PNG, WebP, and GIF image formats in the WASM `draw_lgtm` function
- Preserves original image format when generating output with LGTM overlay
- Improves format compatibility across different image types
- Includes fallback to JPEG for unsupported formats

## Test plan
- [ ] Test with PNG images to ensure proper format preservation
- [ ] Test with WebP images to verify lossless encoding
- [ ] Test with GIF images to confirm compatibility
- [ ] Verify JPEG continues to work with quality setting
- [ ] Test fallback behavior with unsupported formats

🤖 Generated with [Claude Code](https://claude.ai/code)